### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/victory-sokolov/viktorsokolov/security/code-scanning/8](https://github.com/victory-sokolov/viktorsokolov/security/code-scanning/8)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root (top-level), since all jobs in this workflow should share least-privilege defaults. For this lint/test/build workflow, `contents: read` is the minimal and sufficient permission baseline.

Best single fix without changing functionality:
- In `.github/workflows/lint.yml`, insert:
  ```yml
  permissions:
    contents: read
  ```
  immediately after the `on:` triggers block (before `jobs:`), so it applies to the `lint` job and any future jobs unless overridden.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions permissions configuration in the build workflow for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->